### PR TITLE
[jak1] Add generic split for any cell count change (for custom levels)

### DIFF
--- a/jak1/opengoal-jak1-autosplitter.asl
+++ b/jak1/opengoal-jak1-autosplitter.asl
@@ -164,6 +164,14 @@ startup {
 
   // Need Resolution Splits (power cells) - offset is relative from the need resolution block of the struct
   settings.Add("jak1_need_res", true, "Power Cells");
+
+  // Generic Split for any Cell count change (for custom levels)
+  vars.genericSplits = new List<Dictionary<String, dynamic>>();
+  AddOption(vars.genericSplits, "num_power_cells", 0, typeof(uint), null, false, "Split on any Cell pickup", false);
+  AddToSettings(vars.genericSplits, "jak1_need_res");
+  vars.optionLists.Add(vars.genericSplits);
+
+  // Specific Cell/Task Splits
   var jak1_need_res_offset = 424;
 
   // Training


### PR DESCRIPTION
Figured this was an easy way to make autosplitter work with custom levels, without each one requiring an updated autosplit script.

Doesn't /need/ the change in https://github.com/open-goal/jak-project/pull/3996 but works better with it. Otherwise loading a save with cells will do extra autosplits, since the value blips to 0 and back briefly