### PR TITLE
Fix temple % warp split

### DIFF
--- a/jak3/opengoal-jak3-autosplitter.asl
+++ b/jak3/opengoal-jak3-autosplitter.asl
@@ -48,7 +48,7 @@ startup {
   AddOption(vars.anyPercent, "anyPercent_res-arena-training-1", 418, typeof(byte), 1, false, "res-arena-training-1", false);
   AddOption(vars.anyPercent, "anyPercent_arena-fight-1-throne", 546, typeof(byte), 1, false, "arena-fight-1-throne", false);
   AddOption(vars.anyPercent, "anyPercent_res-wascity-chase", 420, typeof(byte), 1, false, "res-wascity-chase", false);
-  AddOption(vars.anyPercent, "anyPercent_res-temple-defend", 469, typeof(byte), 1, false, "res-temple-defend", false);
+  AddOption(vars.anyPercent, "anyPercent_int-temple-defend", 549, typeof(byte), 1, false, "int-temple-defend", false);
   AddOption(vars.anyPercent, "anyPercent_int-city-bbush-get-to-26", 551, typeof(byte), 1, false, "int-city-bbush-get-to-26", false);
   AddOption(vars.anyPercent, "anyPercent_int-city-bbush-get-to-31", 552, typeof(byte), 1, false, "int-city-bbush-get-to-31", false);
   AddOption(vars.anyPercent, "anyPercent_res-palace-ruins-patrol", 475, typeof(byte), 1, false, "res-palace-ruins-patrol", false);
@@ -65,7 +65,7 @@ startup {
   AddOption(vars.noOob, "noOob_arena-fight-1-throne", 546, typeof(byte), 1, false, "arena-fight-1-throne", false);
   AddOption(vars.noOob, "noOob_int-temple-climb", 548, typeof(byte), 1, false, "int-temple-climb", false);
   AddOption(vars.noOob, "noOob_res-temple-climb", 433, typeof(byte), 1, false, "res-temple-climb", false);
-  AddOption(vars.noOob, "noOob_temple-defend-door-4", 549, typeof(byte), 1, false, "temple-defend-door-4", false);
+  AddOption(vars.noOob, "noOob_int-temple-defend", 549, typeof(byte), 1, false, "int-temple-defend", false);
   AddOption(vars.noOob, "noOob_int-city-bbush-get-to-26", 551, typeof(byte), 1, false, "int-city-bbush-get-to-26", false);
   AddOption(vars.noOob, "noOob_res-palace-ruins-patrol", 475, typeof(byte), 1, false, "res-palace-ruins-patrol", false);
   AddOption(vars.noOob, "noOob_res-palace-ruins-attack", 476, typeof(byte), 1, false, "res-palace-ruins-attack", false);
@@ -109,7 +109,7 @@ startup {
   AddOption(vars.anyhero, "anyhero_res-arena-training-1", 418, typeof(byte), 1, false, "res-arena-training-1", false);
   AddOption(vars.anyhero, "anyhero_arena-fight-1-throne", 546, typeof(byte), 1, false, "arena-fight-1-throne", false);
   AddOption(vars.anyhero, "anyhero_res-wascity-chase", 420, typeof(byte), 1, false, "res-wascity-chase", false);
-  AddOption(vars.anyhero, "anyhero_res-temple-defend", 469, typeof(byte), 1, false, "res-temple-defend", false);
+  AddOption(vars.anyhero, "anyhero_int-temple-defend", 549, typeof(byte), 1, false, "int-temple-defend", false);
   AddOption(vars.anyhero, "anyhero_int-city-bbush-get-to-26", 551, typeof(byte), 1, false, "int-city-bbush-get-to-26", false);
   AddOption(vars.anyhero, "anyhero_int-city-bbush-get-to-31", 552, typeof(byte), 1, false, "int-city-bbush-get-to-31", false);
   AddOption(vars.anyhero, "anyhero_res-palace-ruins-patrol", 475, typeof(byte), 1, false, "res-palace-ruins-patrol", false);
@@ -453,7 +453,7 @@ startup {
   AddOption(vars.manualOptions, "arena-fight-1-throne", 546, typeof(byte), 1, false, "arena-fight-1-throne", false);
   AddOption(vars.manualOptions, "nest-eggs-tunnel", 547, typeof(byte), 1, false, "nest-eggs-tunnel", false);
   AddOption(vars.manualOptions, "int-temple-climb", 548, typeof(byte), 1, false, "int-temple-climb", false);
-  AddOption(vars.manualOptions, "temple-defend-door-4", 549, typeof(byte), 1, false, "temple-defend-door-4", false);
+  AddOption(vars.manualOptions, "int-temple-defend", 549, typeof(byte), 1, false, "int-temple-defend", false);
   AddOption(vars.manualOptions, "palace-ruins-patrol-stadium", 550, typeof(byte), 1, false, "palace-ruins-patrol-stadium", false);
   AddOption(vars.manualOptions, "int-city-bbush-get-to-26", 551, typeof(byte), 1, false, "int-city-bbush-get-to-26", false);
   AddOption(vars.manualOptions, "int-city-bbush-get-to-31", 552, typeof(byte), 1, false, "int-city-bbush-get-to-31", false);

--- a/jak3/options.json
+++ b/jak3/options.json
@@ -570,7 +570,7 @@
       "type": "bool"
     },
     {
-      "label": "temple-defend-door-4",
+      "label": "int-temple-defend",
       "type": "bool"
     },
     {
@@ -602,7 +602,7 @@
         "res-arena-training-1",
         "arena-fight-1-throne",
         "res-wascity-chase",
-        "res-temple-defend",
+        "int-temple-defend",
         "int-city-bbush-get-to-26",
         "int-city-bbush-get-to-31",
         "res-palace-ruins-patrol",
@@ -621,7 +621,7 @@
         "arena-fight-1-throne",
         "int-temple-climb",
         "res-temple-climb",
-        "temple-defend-door-4",
+        "int-temple-defend",
         "int-city-bbush-get-to-26",
         "res-palace-ruins-patrol",
         "res-palace-ruins-attack",
@@ -669,7 +669,7 @@
         "res-arena-training-1",
         "arena-fight-1-throne",
         "res-wascity-chase",
-        "res-temple-defend",
+        "int-temple-defend",
         "int-city-bbush-get-to-26",
         "int-city-bbush-get-to-31",
         "res-palace-ruins-patrol",


### PR DESCRIPTION
fix to match https://github.com/open-goal/jak-project/pull/4086

also updates the split used for any% and hero mode, since res-temple-defend doesn't get closed in these routes