### PR TITLE
[jak1] Respect checkbox for light eco final split

### DIFF
--- a/jak1/opengoal-jak1-autosplitter.asl
+++ b/jak1/opengoal-jak1-autosplitter.asl
@@ -540,7 +540,7 @@ split {
   }
 
   // ALWAYS split if the final split condition is true, so no matter what we exhaust all splits until the end
-  if (vars.watchers[vars.finalSplitTask["id"]].Current == vars.finalSplitTask["splitVal"]) {
+  if (settings[vars.finalSplitTask["id"]] && vars.watchers[vars.finalSplitTask["id"]].Current == vars.finalSplitTask["splitVal"]) {
     return true;
   }
 }


### PR DESCRIPTION
checkbox on/off was being ignored, so even when unchecked it would always infinite split once you collected light eco